### PR TITLE
Add RabbiGPT RAG interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# rabbiRag
+# RabbiGPT
+
+RabbiGPT is a minimal Retrieval Augmented Generation (RAG) interface that uses a
+subset of texts from [Sefaria](https://www.sefaria.org/) to answer questions.
+Only five books of the Torah are used (Genesis, Exodus, Leviticus, Numbers and
+Deuteronomy) and all text is pulled from the English translation available on
+Sefaria.
+
+The application consists of a small Flask server with a simple mobile-friendly
+front end. Queries are embedded with `sentence-transformers` and stored in a
+FAISS index. Answers are generated using the OpenAI API with the relevant
+passages passed as context. Each answer includes links to the original text on
+Sefaria.
+
+## Usage
+
+1. Install requirements
+
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+
+2. Set your OpenAI API key
+
+   ```bash
+   export OPENAI_API_KEY=your-key
+   ```
+
+3. Run the app
+
+   ```bash
+   python app.py
+   ```
+
+4. Visit `http://localhost:8000` on your mobile device or simulator.
+
+## Notes
+
+- On first run, the server will fetch the five books from Sefaria's API to
+  build the local index.
+- Network access is required for downloading the texts and for OpenAI API calls.
+- The RAG pipeline returns a list of citations with direct links to Sefaria for
+  each passage used in the answer.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+import os
+from flask import Flask, request, jsonify, render_template
+import openai
+from rabbi_rag import RabbiRAG
+
+# Choose five books with English translations
+BOOKS = [
+    "Genesis",
+    "Exodus",
+    "Leviticus",
+    "Numbers",
+    "Deuteronomy",
+]
+
+rag = RabbiRAG(BOOKS)
+rag.build()
+
+openai.api_key = os.environ.get("OPENAI_API_KEY")
+
+
+def call_openai(prompt):
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0
+    )
+    return resp.choices[0].message["content"].strip()
+
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/ask", methods=["POST"])
+def ask():
+    data = request.get_json()
+    question = data.get("question", "")
+    answer, citations = rag.answer(question, call_openai)
+    return jsonify({"answer": answer, "citations": citations})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/rabbi_rag.py
+++ b/rabbi_rag.py
@@ -1,0 +1,80 @@
+import os
+import json
+import requests
+import numpy as np
+from sentence_transformers import SentenceTransformer
+import faiss
+
+
+def fetch_book(book: str):
+    """Fetch English text of a book from Sefaria"""
+    url = f"https://www.sefaria.org/api/texts/{book}?context=0&commentary=0&pad=0&lang=en"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    data = resp.json()
+    texts = []
+    if isinstance(data.get('text'), list):
+        for i, chapter in enumerate(data['text']):
+            if isinstance(chapter, list):
+                for j, verse in enumerate(chapter):
+                    ref = f"{book} {i+1}:{j+1}"
+                    texts.append((ref, verse))
+            else:
+                ref = f"{book} {i+1}"
+                texts.append((ref, chapter))
+    else:
+        texts.append((book, data.get('text', '')))
+    return texts
+
+
+class RabbiRAG:
+    """Minimal Retrieval-Augmented Generation using Sefaria"""
+    def __init__(self, books, model_name="sentence-transformers/all-MiniLM-L6-v2"):
+        self.books = books
+        self.model = SentenceTransformer(model_name)
+        self.texts = []
+        self.refs = []
+        self.index = None
+
+    def build(self):
+        """Build the FAISS index from the selected books"""
+        for book in self.books:
+            passages = fetch_book(book)
+            for ref, text in passages:
+                self.refs.append(ref)
+                self.texts.append(text)
+        embeddings = self.model.encode(self.texts, show_progress_bar=True)
+        dim = embeddings.shape[1]
+        self.index = faiss.IndexFlatL2(dim)
+        self.index.add(np.array(embeddings).astype('float32'))
+
+    def search(self, query, top_k=5):
+        """Search for relevant passages"""
+        q_emb = self.model.encode([query])
+        D, I = self.index.search(np.array(q_emb).astype('float32'), top_k)
+        results = []
+        for idx in I[0]:
+            ref = self.refs[idx]
+            results.append({
+                'ref': ref,
+                'text': self.texts[idx],
+                'link': f"https://www.sefaria.org/{ref.replace(' ', '.')}"
+            })
+        return results
+
+    def build_context(self, query, top_k=5):
+        """Return formatted context for LLM"""
+        results = self.search(query, top_k)
+        context = "\n".join(f"{r['ref']}: {r['text']}" for r in results)
+        return context, results
+
+    def answer(self, query, llm, top_k=5):
+        """Generate answer from LLM with citations"""
+        context, results = self.build_context(query, top_k)
+        prompt = (
+            "You are RabbiGPT, an assistant answering questions using Jewish texts. "
+            "Use the context passages to answer the question. Provide hyperlinks to sources.\n"
+            f"Context:\n{context}\nQuestion: {query}\nAnswer:"
+        )
+        completion = llm(prompt)
+        return completion, results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+requests
+sentence-transformers
+faiss-cpu
+openai

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,16 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 1em;
+}
+.container {
+    max-width: 600px;
+    margin: auto;
+}
+textarea {
+    width: 100%;
+    height: 100px;
+}
+button {
+    padding: 0.5em 1em;
+    margin-top: 0.5em;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RabbiGPT</title>
+    <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+    <div class="container">
+        <h1>RabbiGPT</h1>
+        <form id="ask-form">
+            <textarea id="question" placeholder="Ask a question..." required></textarea>
+            <button type="submit">Ask</button>
+        </form>
+        <div id="answer"></div>
+        <ul id="sources"></ul>
+    </div>
+    <script>
+        const form = document.getElementById('ask-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const question = document.getElementById('question').value;
+            const res = await fetch('/api/ask', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ question })
+            });
+            const data = await res.json();
+            document.getElementById('answer').textContent = data.answer;
+            const list = document.getElementById('sources');
+            list.innerHTML = '';
+            data.citations.forEach(c => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = c.link;
+                a.textContent = c.ref;
+                a.target = '_blank';
+                li.appendChild(a);
+                list.appendChild(li);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create requirements
- implement RabbiRAG class for retrieval with links to Sefaria
- add Flask server and mobile-friendly webpage
- document running the app

## Testing
- `python -m py_compile app.py rabbi_rag.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf8e91d3083228a23d9a46016e468